### PR TITLE
[Refactor/Bug] Update text-entry to work with new server endpoints. Entry_text is now defined by client

### DIFF
--- a/server/db/dbHelpers.js
+++ b/server/db/dbHelpers.js
@@ -71,7 +71,7 @@ exports.saveEntry = (req, res, log) => {
   User.findOneAndUpdate({user_id: userID}, {$push: {'entries': logEntry}}, {safe: true, upsert: false, new: true})
 
   .then((result) => {
-    console.log('Entry successfully uploaded!', result);
+    console.log('Entry successfully uploaded!');
     res.sendStatus(201);
   })
   .error(err => res.sendStatus(500).send(err))

--- a/server/index.js
+++ b/server/index.js
@@ -25,7 +25,6 @@ app.use(require('morgan')('combined'));
 app.use(cors());
 
 const upload = multer({
-  dest: path.resolve(__dirname, 'api', 'speech', 'audio'),
   storage: multerS3({
     s3: s3,
     bucket: 'bewty',
@@ -34,18 +33,6 @@ const upload = multer({
     },
     key: (req, file, cb) => cb(null, Date.now().toString())
   })
-});
-
-const uploadVideo = multer({
-  dest: path.resolve(__dirname, '..', 'dist', 'upload'),
-  storage: multerS3({
-    s3: s3,
-    bucket: 'smartdiarybewt',
-    metadata: (req, file, cb) => {
-      cb(null, {fieldName: file.fieldname});
-    },
-    key: (req, file, cb) => cb(null, `${Date.now().toString()}.webm`)
-  }),
 });
 
 const getAWSSignedUrl = (req) => {
@@ -160,34 +147,21 @@ app.post('/test', (req, res) => {
   });
 });
 
-app.post('/entry/audio', upload.single('audio'), (req, res) => {
+app.post('/entry', upload.single('media'), (req, res) => {
   watson.promisifiedTone(req.body.text)
   .then(tone => {
     let log = {
       user_id: '123456789', // NOTE: hardcode user id
-      entry_type: 'audio',
-      audio: {
-        bucket: req.file.bucket, // should be same as video later
-        key: req.file.key
-      },
-      text: req.body.text,
-      watson_results: tone
-    };
-    database.saveEntry(req, res, log);
-  });
-});
-
-app.post('/entry/video', uploadVideo.single('video'), (req, res) => {
-  watson.promisifiedTone(req.body.text)
-  .then(tone => {
-    let log = {
-      user_id: '123456789', // NOTE: hardcode user id
-      entry_type: 'video',
+      entry_type: req.body.entryType,
       video: {
-        bucket: req.file.bucket,
-        key: req.file.key,
-        avgData: req.body.avgData,
-        rawData: req.body.rawData,
+        bucket: req.file ? req.file.bucket : null,
+        key: req.file ? req.file.key : null,
+        avgData: req.body.avgData ? req.body.avgData : null,
+        rawData: req.body.rawData ? req.body.rawData : null,
+      },
+      audio: {
+        bucket: req.file ? req.file.bucket : null, // should be same as video later
+        key: req.file ? req.file.key : null,
       },
       text: req.body.text,
       watson_results: tone

--- a/server/index.js
+++ b/server/index.js
@@ -27,7 +27,7 @@ app.use(cors());
 const upload = multer({
   storage: multerS3({
     s3: s3,
-    bucket: 'bewty',
+    bucket: process.env.AWS_S3_BUCKET,
     metadata: (req, file, cb) => {
       cb(null, {fieldName: file.fieldname});
     },

--- a/src/app/components/audioEntry/AudioEntry.jsx
+++ b/src/app/components/audioEntry/AudioEntry.jsx
@@ -93,14 +93,15 @@ class AudioEntry extends Component {
     let self = this;
     let blob = this.state.blob;
     let fd = new FormData();
-    fd.append('audio', blob);
+    fd.append('media', blob);
+    fd.append('entryType', 'audio');
     fd.append('text', this.state.transcript);
 
     const config = {
       headers: { 'content-type': 'multipart/form-data' }
     };
 
-    axios.post('/entry/audio', fd, config)
+    axios.post('/entry', fd, config)
     .then( res => console.log('audio upload to server done', res))
     .catch(err => console.log('audio upload error...', err));
   }

--- a/src/app/components/textEntry/TextEntry.jsx
+++ b/src/app/components/textEntry/TextEntry.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import axios from 'axios';
 
 export default class TextEntry extends React.Component {
   constructor(props) {
@@ -9,24 +10,24 @@ export default class TextEntry extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleClick = this.handleClick.bind(this);
   }
-  
+
   handleChange(event) {
     this.setState({value: event.target.value});
   }
 
   handleSubmit(event) {
     event.preventDefault();
-    let currentScope = this;
-    fetch('http://localhost:3000/transcribe', {
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-      },
-      method: 'POST',
-      body: JSON.stringify({
-        TranscriptionText: currentScope.state.value,
-        textID: 'test123'
-      })
+    const data = {
+      text: this.state.value,
+      entryType: 'text'
+    };
+
+    axios.post('/entry', data)
+    .then( res => console.log('text upload to server done', res))
+    .catch(err => console.log('text upload error...', err));
+
+    this.setState({
+      value: ''
     });
   }
 

--- a/src/app/components/videoEntry/VideoEntry.jsx
+++ b/src/app/components/videoEntry/VideoEntry.jsx
@@ -237,7 +237,8 @@ class VideoEntry extends Component {
 
     let blob = this.state.blob;
     let fd = new FormData();
-    fd.append('video', blob);
+    fd.append('media', blob);
+    fd.append('entryType', 'video');
     fd.append('rawData', JSON.stringify(this.state.rawData));
     fd.append('avgData', JSON.stringify(this.state.avgData));
     fd.append('text', this.state.transcript);
@@ -246,7 +247,7 @@ class VideoEntry extends Component {
       headers: { 'content-type': 'multipart/form-data' }
     };
 
-    axios.post('/entry/video', fd, config)
+    axios.post('/entry', fd, config)
     .then( res => {
       this.setState({ uploading: false });
       console.log('video upload to server COMPLETE:', res);
@@ -259,7 +260,6 @@ class VideoEntry extends Component {
       console.log('video upload to server ERROR:', err);
     });
   }
-
 
   onEnd() {
     this.setState({ start: false, stop: false });


### PR DESCRIPTION
====FE====
- update text-entry to work with new server endpoints --> save into db
- text-entry input clears out after user submits entry 

===BE===
- 'entry-type' is defined by client rather than server 