### PR TITLE
[Style] Format axis of charts

### DIFF
--- a/src/app/components/results/trend-chart/Trend.jsx
+++ b/src/app/components/results/trend-chart/Trend.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import * as V from 'victory';
-import { VictoryScatter,VictoryPie, VictoryZoomContainer, VictoryBar, VictoryLabel, VictoryTheme, VictoryChart } from 'victory';
+import { VictoryScatter,VictoryPie, VictoryZoomContainer, VictoryBar, VictoryLabel, VictoryTheme, VictoryChart, VictoryAxis } from 'victory';
 import exampleData from '../../../../../static/exampleData.js'
 
 class CustomPie extends React.Component {
@@ -133,9 +133,14 @@ export default class Chart extends React.Component {
         height ={750}
         theme={VictoryTheme.material}
         // domain={{y: [0, 5]}}
-        domain={{x: [0, 120]}}
-
+        domain={{x: [-20, 120]}}
       >
+        <VictoryAxis
+          crossAxis={false}
+        />
+        <VictoryAxis
+          offsetX={50}
+          dependentAxis />
         <VictoryScatter
           data={this.state.data}
           labelComponent={


### PR DESCRIPTION
Fix axis so that it does not clutter the percentages near zero
![screen shot 2017-04-26 at 3 35 41 pm](https://cloud.githubusercontent.com/assets/10170685/25460038/45ea323a-2a96-11e7-81e0-619e580460c2.png)

Label for percentages are not always appearing however (not sure why)